### PR TITLE
Fix initial_ctrl! not applying controls to population

### DIFF
--- a/lib/QuanEstimationBase/src/Common/Common.jl
+++ b/lib/QuanEstimationBase/src/Common/Common.jl
@@ -319,6 +319,12 @@ function initial_ctrl!(opt, ctrl0, scheme, p_num, rng)
                 [[(b - a) * rand(rng) + a for j = 1:ctrl_length] for i = 1:ctrl_num]
         end
     end
+
+    for i = 1:p_num
+        param_data(scheme[i]).ctrl = all_ctrl[i]
+
+    end
+
 end
 
 #### initialization velocity for PSO ####


### PR DESCRIPTION
### Summary

Fix `initial_ctrl!` for DE control optimization so that the initial controls from `ini_population` are actually applied to each individual in the population.

### Details

Previously `initial_ctrl!` only updated the local `all_ctrl` array and never wrote back to the `Scheme` objects, so all individuals kept the same `opt.ctrl`. I added a final loop:

```julia
for i = 1:p_num
    param_data(scheme[i]).ctrl = all_ctrl[i]
end