### PR TITLE
fix(docs): remove incompatible DocumenterMarkdown dependency

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,11 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
-DocumenterMarkdown = "997ab1e6-3595-5248-9280-8efb232c3433"
 QuanEstimation = "088c8dff-a786-4a66-974c-03d3f6773f87"
 
-[compat] 
+[compat]
 Documenter = "1.17"
 DocumenterCitations = "1.4"
-DocumenterMarkdown = "0.2"
 julia = "1.11" 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,5 @@
 using QuanEstimation
 using Documenter
-using DocumenterMarkdown
 using DocumenterCitations
 
 bib = CitationBibliography("src/refs.bib")


### PR DESCRIPTION
DocumenterMarkdown v0.2.x only supports Documenter up to v0.27, which conflicts with the required Documenter v1.17. Since DocumenterMarkdown was imported but never actually used in makedocs, remove it entirely.